### PR TITLE
Fixed the loading of JIL/DIL coupled files

### DIFF
--- a/src/resources/gfx/dil-file-reader.ts
+++ b/src/resources/gfx/dil-file-reader.ts
@@ -34,7 +34,7 @@ module Settlers {
             }
 
             this.log.log("Unable to find offset gilIndex:" + gilIndex);
-            return 0;
+            return lastGood;
 
         }
 

--- a/src/resources/gfx/gfx-file-reader.ts
+++ b/src/resources/gfx/gfx-file-reader.ts
@@ -42,6 +42,7 @@ module Settlers {
             let count = offsetTable.getImageCount();
             this.images = new Array<GfxImage>(count);
 
+            let lastGood = 0;
             for (let i = 0; i < count; i++) {
                 const gfxOffset = offsetTable.getImageOffset(i);
 
@@ -50,6 +51,8 @@ module Settlers {
                 if (directionIndexList) {
                     const dirOffset = directionIndexList.reverseLookupOffset(i);
                     jobIndex = jobIndexList.reverseLookupOffset(dirOffset);
+                    jobIndex = jobIndex == -1 ? lastGood : jobIndex;
+                    lastGood = jobIndex;
                 }
 
 

--- a/src/resources/gfx/jil-file-reader.ts
+++ b/src/resources/gfx/jil-file-reader.ts
@@ -27,7 +27,7 @@ module Settlers {
             }
 
             this.log.log("Unable to find offset dirOffset: " + dirOffset);
-            return 0;
+            return -1;
 
         }
 


### PR DESCRIPTION
This fixes the rendering of files that use JIL and DIL
The `gfx-file-reader` did not properly "connect" images that belong together, like the unfinished version of a building with its finished version. These connected images share the same JIL. The JIL file has no entry for those connected images thusly complaining about not finding them.

The fix is to use the previous working JIL, as that belongs to the "father" image, which all connected images belong to

Also the last image doesn't get a proper dil as it is at the end of the file, skipping the for loop and returning a 0, returning the `lastGood` instead, fixes that problem